### PR TITLE
Fixes assembly not opening

### DIFF
--- a/code/modules/integrated/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated/integrated_electronics/core/assemblies.dm
@@ -239,7 +239,7 @@
 			playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
 			interact(user)
 	if(QUALITY_PRYING in I.tool_qualities)
-		if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_WELDING, FAILCHANCE_EASY))
+		if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_PRYING, FAILCHANCE_EASY))
 			opened = !opened
 			user << "<span class='notice'>You [opened ? "opened" : "closed"] \the [src].</span>"
 			update_icon()


### PR DESCRIPTION
Fixes electronic assemblies requiring both a tool that can pry and weld, to just needing prying, like the description says